### PR TITLE
Add Priority feature to resolve cases with multiple spoil recipes

### DIFF
--- a/EXAMPLES/data/spoiled/recipes/bread_to_stone.json
+++ b/EXAMPLES/data/spoiled/recipes/bread_to_stone.json
@@ -5,5 +5,7 @@
   },
   "result": {
     "item": "minecraft:stone"
-  }
+  },
+  "spoilTime": 20,
+  "priority": 5
 }

--- a/common/src/main/java/com/mrbysco/spoiled/compat/ct/SpoilManager.java
+++ b/common/src/main/java/com/mrbysco/spoiled/compat/ct/SpoilManager.java
@@ -25,16 +25,21 @@ import java.util.List;
 public class SpoilManager implements IRecipeManager<SpoilRecipe> {
 
 	@Method
-	public void addSpoiling(String name, IIngredient food, IItemStack spoilStack, int spoilTime) {
+	public void addSpoiling(String name, IIngredient food, IItemStack spoilStack, int spoilTime, int priority) {
 		final ResourceLocation id = new ResourceLocation("crafttweaker", name);
 		final Ingredient foodIngredient = food.asVanillaIngredient();
 		final ItemStack resultItemStack = spoilStack.getInternal();
-		final SpoilRecipe recipe = new SpoilRecipe(id, "", foodIngredient, resultItemStack, spoilTime);
+		final SpoilRecipe recipe = new SpoilRecipe(id, "", foodIngredient, resultItemStack, spoilTime, priority);
 		CraftTweakerAPI.apply(new ActionAddRecipe<>(this, recipe));
 	}
 
 	@Method
-	public void addModSpoiling(String modName, IItemStack spoilStack, int spoilTime) {
+	public void addSpoiling(String name, IIngredient food, IItemStack spoilStack, int spoilTime) {
+		addSpoiling(name, food, spoilStack, spoilTime, 1);
+	}
+
+	@Method
+	public void addModSpoiling(String modName, IItemStack spoilStack, int spoilTime, int priority) {
 		if (Services.PLATFORM.isModLoaded(modName)) {
 			List<Item> edibleFoodList = BuiltInRegistries.ITEM.stream().filter(Item::isEdible).toList();
 			for (Item foundItem : edibleFoodList) {
@@ -42,11 +47,16 @@ public class SpoilManager implements IRecipeManager<SpoilRecipe> {
 				if (foundItem != spoilStack.getInternal().getItem() && location != null && location.getNamespace().equals(modName)) {
 					String itemLocation = location.toString().replace(":", "_");
 					ResourceLocation id = new ResourceLocation("crafttweaker", itemLocation);
-					SpoilRecipe recipe = new SpoilRecipe(id, "", Ingredient.of(new ItemStack(foundItem)), spoilStack.getInternal(), spoilTime);
+					SpoilRecipe recipe = new SpoilRecipe(id, "", Ingredient.of(new ItemStack(foundItem)), spoilStack.getInternal(), spoilTime, priority);
 					CraftTweakerAPI.apply(new ActionAddRecipe<>(this, recipe));
 				}
 			}
 		}
+	}
+
+	@Method
+	public void addModSpoiling(String modName, IItemStack spoilStack, int spoilTime) {
+		addModSpoiling(modName, spoilStack, spoilTime, 1);
 	}
 
 	@Override

--- a/common/src/main/java/com/mrbysco/spoiled/recipe/SpoilRecipe.java
+++ b/common/src/main/java/com/mrbysco/spoiled/recipe/SpoilRecipe.java
@@ -27,13 +27,15 @@ public class SpoilRecipe implements Recipe<Container> {
 	protected final Ingredient ingredient;
 	protected final ItemStack result;
 	protected final int spoilTime;
+	protected final int priority; // higher numbers are higher priority
 
-	public SpoilRecipe(ResourceLocation id, String group, Ingredient ingredient, ItemStack stack, int spoilTime) {
+	public SpoilRecipe(ResourceLocation id, String group, Ingredient ingredient, ItemStack stack, int spoilTime, int priority) {
 		this.id = id;
 		this.group = group;
 		this.ingredient = ingredient;
 		this.result = stack;
 		this.spoilTime = spoilTime;
+		this.priority = priority;
 	}
 
 	@Override
@@ -44,6 +46,10 @@ public class SpoilRecipe implements Recipe<Container> {
 	@Override
 	public boolean matches(Container inv, Level level) {
 		return this.getIngredients().get(0).test(inv.getItem(0));
+	}
+
+	public int getPriority() {
+		return this.priority;
 	}
 
 	public ItemStack assemble(Container inventory, RegistryAccess registryAccess) {
@@ -111,7 +117,8 @@ public class SpoilRecipe implements Recipe<Container> {
 			}
 
 			int spoilTime = GsonHelper.getAsInt(jsonObject, "spoiltime", Services.PLATFORM.getDefaultSpoilTime());
-			return new SpoilRecipe(recipeId, s, ingredient, itemstack, spoilTime);
+			int priority = GsonHelper.getAsInt(jsonObject, "priority", 1);
+			return new SpoilRecipe(recipeId, s, ingredient, itemstack, spoilTime, priority);
 		}
 
 		@Nullable
@@ -121,7 +128,8 @@ public class SpoilRecipe implements Recipe<Container> {
 			Ingredient ingredient = Ingredient.fromNetwork(buffer);
 			ItemStack itemstack = buffer.readItem();
 			int spoilTime = buffer.readVarInt();
-			return new SpoilRecipe(recipeId, s, ingredient, itemstack, spoilTime);
+			int priority = buffer.readVarInt();
+			return new SpoilRecipe(recipeId, s, ingredient, itemstack, spoilTime, priority);
 		}
 
 		@Override
@@ -130,6 +138,7 @@ public class SpoilRecipe implements Recipe<Container> {
 			recipe.ingredient.toNetwork(buffer);
 			buffer.writeItem(recipe.result);
 			buffer.writeVarInt(recipe.spoilTime);
+			buffer.writeVarInt(recipe.priority);
 		}
 	}
 }

--- a/common/src/main/java/com/mrbysco/spoiled/util/SpoilHelper.java
+++ b/common/src/main/java/com/mrbysco/spoiled/util/SpoilHelper.java
@@ -41,11 +41,17 @@ public class SpoilHelper {
 				ItemStack spoilStack = SpoiledConfigCache.getDefaultSpoilItem();
 				String result = spoilStack.isEmpty() ? "to_air" : "to_" + BuiltInRegistries.ITEM.getKey(spoilStack.getItem()).getPath();
 				String recipePath = "everything_" + stackLocation.getPath() + result;
-				return new SpoilRecipe(new ResourceLocation(Constants.MOD_ID, recipePath), "", Ingredient.of(stack), spoilStack, Services.PLATFORM.getDefaultSpoilTime());
+				return new SpoilRecipe(new ResourceLocation(Constants.MOD_ID, recipePath), "", Ingredient.of(stack), spoilStack, Services.PLATFORM.getDefaultSpoilTime(), 1);
 			}
 		} else {
-			return level.getRecipeManager().getRecipeFor(SpoiledRecipes.SPOIL_RECIPE_TYPE.get(),
-					new SimpleContainer(stack), level).orElse(null);
+			return level.getRecipeManager()
+					.getRecipesFor(SpoiledRecipes.SPOIL_RECIPE_TYPE.get(), new SimpleContainer(stack), level)
+					.stream()
+					.reduce(null,
+							(highest_priority, next) ->
+							highest_priority == null || next.getPriority() > highest_priority.getPriority() 
+								? next
+								: highest_priority);
 		}
 		return null;
 	}


### PR DESCRIPTION
# Summary
There compatibility tags such as `forge:crops` and it would be very useful to be able to set a default SpoilRecipe for a category like that, while also being able to override the category with a higher-priority recipe (for example make potatoes spoil slower than other crops).

Creating two recipes like this is already possible, however I have noticed that the order that runtime stores and returns the recipes is arbitrary and not affected by ordering in scripts, so it is likely that the category recipe will always be returned even when there is a lower-level recipe that you would prefer to be used.

This PR adds an optional `priority` attribute to the SpoilRecipe, and changes the lookup to retrieve all relevant recipes and and select the highest-priority recipe.

# Test plan
After creating a new world, under the `datapacks` folder create `test/pack.meta`
```
{
  "pack": {
    "pack_format": 15,
    "description": "Tutorial Data Pack"
  }
}
```
then create `test/data/testpack/recipes/test_recipe.json`
```
{
  "type": "spoiled:spoil_recipe",
  "ingredient": {
	"item": "minecraft:bread"
  },
  "result": {
    "item": "minecraft:stone"
  },
  "spoilTime": 1,
  "priority": 1
}
```
then in the `scripts` folder create `test_script.zs`
```
import mods.spoiled.SpoilingManager;

var mngr = <recipetype:spoiled:spoil_recipe>;

mngr.addSpoiling("minecraft_bread", <item:minecraft:bread>, <item:minecraft:gold_ore>, 2);
mngr.addSpoiling("minecraft_breadlow", <item:minecraft:bread>, <item:minecraft:iron_ore>, 2, 2);
```

Then, play with the priority values and verify that the highest-priority recipe is always used.